### PR TITLE
Add fallback to docker-compose running inside container

### DIFF
--- a/cmd/sandbox-ce/cmd/install.go
+++ b/cmd/sandbox-ce/cmd/install.go
@@ -19,7 +19,6 @@ func (c *installCmd) Execute(args []string) error {
 	}
 
 	err = compose.Run(context.Background(), "up")
-
 	if err != nil {
 		return err
 	}

--- a/cmd/sandbox-ce/compose/compose.go
+++ b/cmd/sandbox-ce/compose/compose.go
@@ -19,9 +19,7 @@ import (
 // that it's not already present in the system
 const composeContainerPath = "https://github.com/docker/compose/releases/download/1.24.0/run.sh"
 
-var envKeys = map[string]bool{
-	"GITBASE_REPOS_DIR": true,
-}
+var envKeys = []string{"GITBASE_REPOS_DIR"}
 
 type Compose struct {
 	bin string
@@ -31,7 +29,7 @@ func (c *Compose) Run(ctx context.Context, arg ...string) error {
 	cmd := exec.CommandContext(ctx, c.bin, arg...)
 
 	var compOpts []string
-	for key := range envKeys {
+	for _, key := range envKeys {
 		val, ok := os.LookupEnv(key)
 		if !ok {
 			continue

--- a/cmd/sandbox-ce/compose/compose.go
+++ b/cmd/sandbox-ce/compose/compose.go
@@ -14,6 +14,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+// composeContainerPath is the url docker-compose is downloaded from in case
+// that it's not already present in the system
 const composeContainerPath = "https://github.com/docker/compose/releases/download/1.24.0/run.sh"
 
 var envKeys = map[string]bool{

--- a/cmd/sandbox-ce/compose/compose.go
+++ b/cmd/sandbox-ce/compose/compose.go
@@ -40,9 +40,9 @@ func (c *Compose) Run(ctx context.Context, arg ...string) error {
 		compOpts = append(compOpts, fmt.Sprintf("-e %s=%s", key, val))
 	}
 
-	cmd.Env = []string{
-		fmt.Sprintf("COMPOSE_OPTIONS=%s", strings.Join(compOpts, " ")),
-	}
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("COMPOSE_OPTIONS=%s", strings.Join(compOpts, " ")))
+
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/cmd/sandbox-ce/compose/compose.go
+++ b/cmd/sandbox-ce/compose/compose.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/mitchellh/go-homedir"
@@ -108,6 +109,10 @@ func getOrInstallComposeContainer() (string, error) {
 }
 
 func downloadCompose(path string) error {
+	if runtime.GOOS == "windows" {
+		return fmt.Errorf("compose in container is not compatible with Windows")
+	}
+
 	out, err := os.Create(path)
 	if err != nil {
 		return err

--- a/cmd/sandbox-ce/compose/compose.go
+++ b/cmd/sandbox-ce/compose/compose.go
@@ -2,16 +2,133 @@ package compose
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/pkg/errors"
 )
 
-func Run(ctx context.Context, arg ...string) error {
-	cmd := exec.CommandContext(ctx, "docker-compose", arg...)
+const composeContainerPath = "https://github.com/docker/compose/releases/download/1.24.0/run.sh"
 
+var envKeys = map[string]bool{
+	"GITBASE_REPOS_DIR": true,
+}
+
+type Compose struct {
+	bin string
+}
+
+func (c *Compose) Run(ctx context.Context, arg ...string) error {
+	cmd := exec.CommandContext(ctx, c.bin, arg...)
+
+	var compOpts []string
+	for key := range envKeys {
+		val, ok := os.LookupEnv(key)
+		if !ok {
+			continue
+		}
+
+		compOpts = append(compOpts, fmt.Sprintf("-e %s=%s", key, val))
+	}
+
+	cmd.Env = []string{
+		fmt.Sprintf("COMPOSE_OPTIONS=%s", strings.Join(compOpts, " ")),
+	}
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
 	return cmd.Run()
+}
+
+func NewCompose() (*Compose, error) {
+	bin, err := getOrInstallComposeBinary()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Compose{bin: bin}, nil
+}
+
+func getOrInstallComposeBinary() (string, error) {
+	path, err := exec.LookPath("docker-compose")
+	if err == nil {
+		bin := strings.TrimSpace(path)
+		if bin != "" {
+			return bin, nil
+		}
+	}
+
+	path, err = getOrInstallComposeContainer()
+	if err != nil {
+		return "", errors.Wrapf(err, "error while getting docker-compose container")
+	}
+
+	return path, nil
+}
+
+func getOrInstallComposeContainer() (string, error) {
+	homedir, err := homedir.Dir()
+	if err != nil {
+		return "", errors.Wrapf(err, "unable to get home dir")
+	}
+
+	dirPath := filepath.Join(homedir, ".srcd", "bin")
+	path := filepath.Join(dirPath, "docker-compose")
+
+	if _, err := os.Stat(path); err == nil {
+		return path, nil
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+
+	err = os.MkdirAll(dirPath, os.ModePerm)
+	if err != nil {
+		return "", errors.Wrapf(err, "error while creating directory %s", dirPath)
+	}
+
+	if err := downloadCompose(path); err != nil {
+		return "", errors.Wrapf(err, "error downloading %s", composeContainerPath)
+	}
+
+	cmd := exec.CommandContext(context.Background(), "chmod", "+x", path)
+	if err := cmd.Run(); err != nil {
+		return "", errors.Wrapf(err, "cannot change permission to %s", path)
+	}
+
+	return path, nil
+}
+
+func downloadCompose(path string) error {
+	out, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+
+	defer out.Close()
+
+	resp, err := http.Get(composeContainerPath)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	return err
+}
+
+func Run(ctx context.Context, arg ...string) error {
+	comp, err := NewCompose()
+	if err != nil {
+		return err
+	}
+
+	return comp.Run(ctx, arg...)
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/jessevdk/go-flags v1.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.1 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
+	github.com/mitchellh/go-homedir v1.1.0
+	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.1 // indirect
 	github.com/src-d/envconfig v1.0.0 // indirect
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,10 @@ github.com/mattn/go-isatty v0.0.5 h1:tHXDdz1cpzGaovsTB+TVB8q90WEokoVmfMqoVcrLUgw
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.4.1 h1:GL2rEmy6nsikmW0r8opw9JIRScdMF5hA8cOYLH7In1k=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=


### PR DESCRIPTION
This depends on #1.

If `docker-compose` is not installed in the host, then we fallback to `docker-compose` run inside docker container. The utility binary that runs `docker-compose` inside a container is saved into `~/.srcd/bin`.