### PR TITLE
Add a UAST modal to SqlLab tab

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,7 +53,8 @@ RUN pip install --upgrade setuptools pip \
 COPY --chown=superset:superset superset/superset superset
 
 ENV PATH=/home/superset/superset/bin:$PATH \
-    PYTHONPATH=/home/superset/superset/:$PYTHONPATH
+    PYTHONPATH=/home/superset/:$PYTHONPATH \
+    SUPERSET_CONFIG_PATH=/home/superset/superset/superset_config.py
 
 USER superset
 

--- a/srcd/superset/assets/src/components/FilterableTable/CellRenderer.jsx
+++ b/srcd/superset/assets/src/components/FilterableTable/CellRenderer.jsx
@@ -1,0 +1,31 @@
+/* eslint-disable no-unused-vars */
+import React from 'react';
+import UASTButton from './UASTButton';
+
+function isUAST(st) {
+  try {
+    JSON.parse(st);
+    return st.includes('"@pos"');
+  } catch (error) {
+    return false;
+  }
+}
+
+function cellRenderer({
+  cellData,
+  columnData,
+  columnIndex,
+  dataKey,
+  isScrolling,
+  rowData,
+  rowIndex,
+}) {
+  const st = String(cellData);
+  if (isUAST(st)) {
+    return (<UASTButton uast={st} />);
+  }
+
+  return st;
+}
+
+export { cellRenderer, isUAST };

--- a/srcd/superset/assets/src/components/FilterableTable/UASTButton.jsx
+++ b/srcd/superset/assets/src/components/FilterableTable/UASTButton.jsx
@@ -1,0 +1,54 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Button } from 'react-bootstrap';
+
+import UASTModal from '../../uast/components/UASTModal';
+
+class UastButton extends React.PureComponent {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      showModal: false,
+    };
+  }
+
+  render() {
+    // Ideally there would be a UASTModal in a higher html element, and this
+    // button onClick would send a redux action to show the modal. To make
+    // the code as independent as possible from the rest of Superset the
+    // UASTModal is contained in this row cell.
+    // To avoid actually having one hidden modal per row cell, it is defined
+    // as null unless we are really going to open the modal.
+
+    let modal = null;
+
+    if (this.state.showModal) {
+      const uast = JSON.parse(this.props.uast);
+
+      modal = (<UASTModal
+        show={this.state.showModal}
+        uast={uast}
+        onHide={() => this.setState({ showModal: false })}
+      />);
+    }
+
+    return (
+      <div>
+        <Button
+          bsSize="small"
+          onClick={() => this.setState({ showModal: true })}
+        >
+          <i className="fa fa-align-left text-muted" /> UAST
+        </Button>
+        {modal}
+      </div>);
+  }
+}
+
+UastButton.propTypes = {
+  actions: PropTypes.object,
+  uast: PropTypes.string,
+};
+
+export default  UastButton;

--- a/srcd/superset/assets/src/uast/components/UASTModal.jsx
+++ b/srcd/superset/assets/src/uast/components/UASTModal.jsx
@@ -1,0 +1,38 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Modal } from 'react-bootstrap';
+
+import UASTViewer from './UASTViewer';
+import '../stylesheets/UASTModal.less';
+
+class UastModal extends React.PureComponent {
+  render() {
+    let modalContent = <div />;
+    let showModal = false;
+
+    if (this.props.uast) {
+      showModal = true;
+      modalContent = <UASTViewer uast={this.props.uast} />;
+    }
+
+    return (
+      <Modal
+        show={showModal}
+        onHide={this.props.onHide}
+        bsSize="large"
+      >
+        <Modal.Header closeButton>
+          <Modal.Title>UAST</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>{modalContent}</Modal.Body>
+      </Modal>);
+  }
+}
+
+UastModal.propTypes = {
+  show: PropTypes.bool.isRequired,
+  uast: PropTypes.arrayOf(PropTypes.object).isRequired,
+  onHide: PropTypes.func.isRequired,
+};
+
+export default UastModal;

--- a/srcd/superset/assets/src/uast/components/UASTViewer.jsx
+++ b/srcd/superset/assets/src/uast/components/UASTViewer.jsx
@@ -1,0 +1,43 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import UASTViewerPane from './UASTViewerPane';
+
+class UASTViewer extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      loading: false,
+      showLocations: false,
+    };
+
+    this.handleShowLocationsChange = this.handleShowLocationsChange.bind(this);
+  }
+
+  handleShowLocationsChange() {
+    this.setState({ showLocations: !this.state.showLocations });
+  }
+
+  render() {
+    const { showLocations, loading } = this.state;
+    const uastViewerProps = { initialUast: this.props.uast };
+
+    return (
+      <div className="pg-uast-viewer">
+        <UASTViewerPane
+          loading={loading}
+          uastViewerProps={uastViewerProps}
+          showLocations={showLocations}
+          handleShowLocationsChange={this.handleShowLocationsChange}
+        />
+      </div>
+    );
+  }
+}
+
+UASTViewer.propTypes = {
+  uast: PropTypes.array,
+  protobufs: PropTypes.string,
+};
+
+export default UASTViewer;

--- a/srcd/superset/assets/src/uast/components/UASTViewerPane.jsx
+++ b/srcd/superset/assets/src/uast/components/UASTViewerPane.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import UASTViewer from 'uast-viewer';
+import 'uast-viewer/dist/default-theme.css';
+import '../stylesheets/UASTViewerPane.less';
+
+function UASTViewerPane({
+  loading,
+  uastViewerProps,
+  showLocations,
+  handleShowLocationsChange,
+}) {
+  let content = null;
+
+  const uast = uastViewerProps.uast || uastViewerProps.initialUast;
+  if (loading) {
+    content = <div>loading...</div>;
+  } else if (uast) {
+    content = (
+      <UASTViewer
+        {...uastViewerProps}
+        showLocations={showLocations}
+      />
+    );
+  }
+
+  return (
+    <div className="uast-viewer-pane">
+      <div className="show-locations-wrapper">
+        <label htmlFor="showLocations">
+          <input
+            id="showLocations"
+            type="checkbox"
+            checked={showLocations}
+            onChange={handleShowLocationsChange}
+          />
+          <span>Show locations</span>
+        </label>
+      </div>
+      {content}
+    </div>
+  );
+}
+
+UASTViewerPane.propTypes = {
+  loading: PropTypes.bool,
+  uastViewerProps: PropTypes.object,
+  showLocations: PropTypes.bool,
+  handleShowLocationsChange: PropTypes.func.isRequired,
+};
+
+export default UASTViewerPane;

--- a/srcd/superset/assets/src/uast/stylesheets/UASTModal.less
+++ b/srcd/superset/assets/src/uast/stylesheets/UASTModal.less
@@ -1,0 +1,9 @@
+// make modal window "fullscreen"
+.modal-lg .modal-body {
+    height: ~'calc(100vh - 150px)';
+
+    .uast-viewer {
+        height: 100%;
+        overflow-y: auto;
+    }
+}

--- a/srcd/superset/assets/src/uast/stylesheets/UASTViewerPane.less
+++ b/srcd/superset/assets/src/uast/stylesheets/UASTViewerPane.less
@@ -1,0 +1,31 @@
+.uast-viewer-pane {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+
+    .show-locations-wrapper {
+        flex: 0 0 auto;
+
+        min-height: 45px;
+        padding: 5px 0px 5px 20px;
+        background: white;
+        border-bottom: solid 1px fade(gray, 50%);
+
+        label {
+            font-weight: normal;
+            margin-right: 40px;
+
+            span {
+                margin-left: 10px;
+            }
+
+            &:last-of-type {
+                margin-right: 10px;
+            }
+        }
+    }
+
+    .uast-viewer {
+        flex: 1 1 auto;
+    }
+}

--- a/superset/requirements-dev.txt
+++ b/superset/requirements-dev.txt
@@ -22,7 +22,7 @@ flake8==3.6.0
 flask-cors==3.0.6
 ipdb==0.11
 mysqlclient==1.3.13
-pip-tools==3.1.0
+pip-tools==3.6.1
 psycopg2-binary==2.7.5
 pycodestyle==2.4.0
 pyhive==0.6.1

--- a/superset/requirements.txt
+++ b/superset/requirements.txt
@@ -8,6 +8,7 @@ alembic==1.0.0            # via flask-migrate
 amqp==2.3.2               # via kombu
 asn1crypto==0.24.0        # via cryptography
 babel==2.6.0              # via flask-babel
+bblfsh==3.0.4
 billiard==3.5.0.4         # via celery
 bleach==3.0.2
 celery==4.2.0
@@ -21,6 +22,8 @@ croniter==0.3.29
 cryptography==2.4.2
 decorator==4.3.0          # via retry
 defusedxml==0.5.0         # via python3-openid
+docker-pycreds==0.4.0     # via docker
+docker==3.7.2             # via bblfsh
 flask-appbuilder==1.12.1
 flask-babel==0.11.1       # via flask-appbuilder
 flask-caching==1.4.0
@@ -32,6 +35,8 @@ flask-sqlalchemy==2.3.2   # via flask-appbuilder, flask-migrate
 flask-wtf==0.14.2
 flask==1.0.2
 geopy==1.11.0
+grpcio-tools==1.20.1      # via bblfsh
+grpcio==1.20.1            # via bblfsh, grpcio-tools
 gunicorn==19.8.0
 humanize==0.5.1
 idna==2.6
@@ -47,6 +52,7 @@ pandas==0.23.4
 parsedatetime==2.0.0
 pathlib2==2.3.0
 polyline==1.3.2
+protobuf==3.7.1           # via bblfsh, grpcio-tools
 py==1.7.0                 # via retry
 pycparser==2.19           # via cffi
 pydruid==0.5.0
@@ -60,7 +66,7 @@ requests==2.20.0
 retry==0.9.2
 selenium==3.141.0
 simplejson==3.15.0
-six==1.11.0               # via bleach, cryptography, isodate, pathlib2, polyline, pydruid, python-dateutil, sqlalchemy-utils, wtforms-json
+six==1.11.0               # via bleach, cryptography, docker, docker-pycreds, grpcio, isodate, pathlib2, polyline, protobuf, pydruid, python-dateutil, sqlalchemy-utils, websocket-client, wtforms-json
 sqlalchemy-utils==0.32.21
 sqlalchemy==1.3.1
 sqlparse==0.2.4
@@ -68,6 +74,7 @@ unicodecsv==0.14.1
 urllib3==1.22             # via requests, selenium
 vine==1.1.4               # via amqp
 webencodings==0.5.1       # via bleach
+websocket-client==0.56.0  # via docker
 werkzeug==0.14.1          # via flask
 wtforms-json==0.3.3
 wtforms==2.2.1            # via flask-wtf, wtforms-json

--- a/superset/setup.py
+++ b/superset/setup.py
@@ -69,6 +69,7 @@ setup(
     zip_safe=False,
     scripts=['superset/bin/superset'],
     install_requires=[
+        'bblfsh>=3.0.3',
         'bleach>=3.0.2, <4.0.0',
         'celery>=4.2.0, <5.0.0',
         'click>=6.0, <7.0.0',  # click >=7 forces "-" instead of "_"
@@ -77,7 +78,7 @@ setup(
         'croniter>=0.3.28',
         'cryptography>=2.4.2',
         'flask>=1.0.0, <2.0.0',
-        'flask-appbuilder>=1.12.1, <2.0.0',
+        'flask-appbuilder==1.12.1',
         'flask-caching',
         'flask-compress',
         'flask-migrate',

--- a/superset/superset/assets/package-lock.json
+++ b/superset/superset/assets/package-lock.json
@@ -8045,7 +8045,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8066,12 +8067,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8086,17 +8089,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8213,7 +8219,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8225,6 +8232,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8239,6 +8247,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8246,12 +8255,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8270,6 +8281,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8350,7 +8362,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8362,6 +8375,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8447,7 +8461,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8483,6 +8498,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8502,6 +8518,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8545,12 +8562,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/superset/superset/assets/package.json
+++ b/superset/superset/assets/package.json
@@ -70,6 +70,7 @@
     "brace": "^0.11.1",
     "classnames": "^2.2.5",
     "d3": "^3.5.17",
+    "codemirror": "^5.46.0",
     "d3-array": "^1.2.4",
     "d3-cloud": "^1.2.1",
     "d3-color": "^1.2.0",
@@ -103,6 +104,7 @@
     "react-bootstrap": "^0.31.5",
     "react-bootstrap-dialog": "^0.10.0",
     "react-bootstrap-slider": "2.1.5",
+    "react-codemirror2": "^5.1.0",
     "react-color": "^2.13.8",
     "react-datetime": "^2.14.0",
     "react-dnd": "^2.5.4",
@@ -133,6 +135,7 @@
     "shortid": "^2.2.6",
     "srcdoc-polyfill": "^1.0.0",
     "supercluster": "^4.1.1",
+    "uast-viewer": "^0.4.0",
     "underscore": "^1.8.3",
     "urijs": "^1.18.10",
     "viewport-mercator-project": "^5.0.0"

--- a/superset/superset/assets/src/components/FilterableTable/FilterableTable.jsx
+++ b/superset/superset/assets/src/components/FilterableTable/FilterableTable.jsx
@@ -28,6 +28,8 @@ import {
 } from 'react-virtualized';
 import { getTextWidth } from '../../modules/visUtils';
 
+import { cellRenderer, isUAST } from './CellRenderer';
+
 const propTypes = {
   orderedColumnKeys: PropTypes.array.isRequired,
   data: PropTypes.array.isRequired,
@@ -80,7 +82,14 @@ export default class FilterableTable extends PureComponent {
     const widthsByColumnKey = {};
     this.props.orderedColumnKeys.forEach((key) => {
       const colWidths = this.list
-        .map(d => getTextWidth(d[key]) + PADDING) // get width for each value for a key
+        .map((d) => {
+          // TODO hardcoded, implement a better way
+          if (isUAST(d[key])) {
+            return 150;
+          }
+
+          return getTextWidth(d[key]) + PADDING;
+        }) // get width for each value for a key
         .push(getTextWidth(key) + PADDING); // add width of column key to end of list
       // set max width as value for key
       widthsByColumnKey[key] = Math.max(...colWidths);
@@ -201,6 +210,7 @@ export default class FilterableTable extends PureComponent {
                 dataKey={columnKey}
                 disableSort={false}
                 headerRenderer={this.headerRenderer}
+                cellRenderer={cellRenderer}
                 width={this.widthsForColumnsByKey[columnKey]}
                 label={columnKey}
                 key={columnKey}


### PR DESCRIPTION
Contains the same frontend code as in https://github.com/src-d/superset/pull/1.

To upgrade requirements.txt I had to upgrade `pip-tools` to 3.6.1. The version shipped in `requirements.txt` was not working for me, `pip-compile --output-file requirements.txt setup.py` failed.
The new `pip-tools` was upgrading the version for `flash-appbuilder`, so I pinned it to the previously installed version.

The backend code in this PR is different from https://github.com/src-d/superset/pull/1. In that one the json encoder was hijacked to unmarshal bytes as UAST JSON string. But that json encoder is not consistently used in the Superset code. For example an async call will try to store a query result as JSON as an intermediate step, and that encoding will fail is there is binary data that is not UTF8.

With the code in this PR the data is intercepted as it is received from the sql driver, and if a UAST binary column is found it gets replaced with a string containing the JSON of that UAST.

![image](https://user-images.githubusercontent.com/1469173/57030817-e0b0d180-6c3d-11e9-8e52-ca95573c7478.png)

![image](https://user-images.githubusercontent.com/1469173/57030844-f45c3800-6c3d-11e9-84eb-1a301901869d.png)
