### PR TITLE
Add basic travis conf for releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,48 @@
+branches:
+  only:
+    - master
+    - /^v\d+\.\d+(\.\d+)?(-\S*)?$/
+
+dist: xenial
+sudo: required
+
+language: go
+go_import_path: github.com/src-d/superset-compose
+go:
+  - 1.12.x
+env:
+  - GO111MODULE=on
+
+matrix:
+  fast_finish: true
+
+services:
+  - docker
+
+stages:
+  - name: tests
+  - name: release
+    if: tag IS present
+
+jobs:
+  include:
+    - stage: tests
+      name: 'Go Unit Tests'
+      script:
+        - make packages
+        - make test-coverage
+
+    - stage: release
+      name: 'Release to GitHub and Docker Hub'
+      script:
+        - make packages
+      deploy:
+        provider: releases
+        api_key: $GITHUB_TOKEN
+        file_glob: true
+        file: build/*.tar.gz
+        skip_cleanup: true
+        on:
+          all_branches: true
+      after_deploy:
+        - make superset-docker-push-latest-release

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Follow original superset instructions for [Flask server](https://github.com/apac
 ### Build docker image
 
 ```
-make superset-build
+VERSION=latest make superset-build
 ```
 
 Image name defined in Makefile and matches the one in docker-compose.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - postgres:/var/lib/postgresql/data
 
   superset:
-    image: smacker/superset:demo-with-bblfsh
+    image: src-d/superset:latest
     restart: unless-stopped
     environment:
       POSTGRES_DB: superset


### PR DESCRIPTION
This PR adds basic travis conf to build the docker image on tag.
One downside of the configuration is that we will need to tag and release both the go cmd and the docker image, even if we only want to release one.
But I think this is acceptable for now, there is not need to create complex rules to build one or the other depending on the tag name. At some point we may want to divide the project and have the go cli live in a separate repo.

The docker-compose file for now needs `smacker/superset:demo-with-bblfsh`, so in order to build and test locally we need to run it as `VERSION=demo-with-bblfsh make superset-build`. When we do the first proper release under the `src-d` org I guess we'll want to change the version to be latest.