### PR TITLE
Use consistency: delegated for gitbase volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.2'
 services:
   bblfsh:
     image: bblfsh/bblfshd:v2.13.0-drivers
@@ -15,7 +15,11 @@ services:
     depends_on:
       - bblfsh
     volumes:
-      - ${GITBASE_REPOS_DIR}:/opt/repos
+      - type: bind
+        source: ${GITBASE_REPOS_DIR}
+        target: /opt/repos
+        read_only: true
+        consistency: delegated
 
   bblfsh-web:
     image: bblfsh/web:v0.11.0


### PR DESCRIPTION
To avoid performance penalty on MacOS and Windows.
I also set `read_only: true` just in case

Signed-off-by: Maxim Sukharev <max@smacker.ru>