### PR TITLE
[sqllab] Cancel query to database on query stop

### DIFF
--- a/superset/superset/db_engine_specs.py
+++ b/superset/superset/db_engine_specs.py
@@ -414,6 +414,16 @@ class BaseEngineSpec(object):
         """
         return label
 
+    @classmethod
+    def get_connection_id(cls, cursor):
+        """ Returns connection id for a cursor """
+        return None
+
+    @classmethod
+    def cancel_query(cls, cursor, query):
+        """ Cancels query in the underlying database """
+        pass
+
 
 class PostgresBaseEngineSpec(BaseEngineSpec):
     """ Abstract class for Postgres 'like' databases """
@@ -725,6 +735,17 @@ class MySQLEngineSpec(BaseEngineSpec):
         except Exception:
             pass
         return message
+
+    @classmethod
+    def get_connection_id(cls, cursor):
+        cursor.execute('SELECT CONNECTION_ID()')
+        row = cursor.fetchone()
+        return row[0]
+
+    @classmethod
+    def cancel_query(cls, cursor, query):
+        if query.connection_id:
+            cursor.execute('KILL CONNECTION %d' % query.connection_id)
 
 
 class PrestoEngineSpec(BaseEngineSpec):

--- a/superset/superset/migrations/versions/dd907ff5ac79_add_connection_id_to_query_model.py
+++ b/superset/superset/migrations/versions/dd907ff5ac79_add_connection_id_to_query_model.py
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add_connection_id_to_query_model
+
+Revision ID: dd907ff5ac79
+Revises: c82ee8a39623
+Create Date: 2019-05-17 15:39:05.611216
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'dd907ff5ac79'
+down_revision = 'c82ee8a39623'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('query', sa.Column('connection_id', sa.Integer(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('query', 'connection_id')

--- a/superset/superset/models/sql_lab.py
+++ b/superset/superset/models/sql_lab.py
@@ -69,6 +69,8 @@ class Query(Model, ExtraJSONMixin):
     error_message = Column(Text)
     # key used to store the results in the results backend
     results_key = Column(String(64), index=True)
+    # connection_id stores id of an underlying connection to database
+    connection_id = Column(Integer, nullable=True)
 
     # Using Numeric in place of DateTime for sub-second precision
     # stored as seconds since epoch, allowing for milliseconds

--- a/superset/superset/views/core.py
+++ b/superset/superset/views/core.py
@@ -2462,6 +2462,7 @@ class Superset(BaseSupersetView):
             )
             query.status = QueryStatus.STOPPED
             db.session.commit()
+            sql_lab.cancel_query(query, g.user.username if g.user else None)
         except Exception:
             pass
         return self.json_response('OK')


### PR DESCRIPTION
- Add new attribute into Query model that keeps ID of an underlying
connection to database for this query
- Add `get_connection_id` method to EngineSpec that retrieves connection
id for a cursor.
- `execute_sql_statements` before executing queries retrieves and saves
connection id into Query
- Stop handler calls new `cancel_query` method of EngineSpec

Both new methods are implemented only for MySQL for now.
`cancel_query` uses KILL CONNECTION to terminate the statement.

Ref: #35