### PR TITLE
Add docker-compose.yml to release assets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,9 @@ jobs:
         provider: releases
         api_key: $GITHUB_TOKEN
         file_glob: true
-        file: build/*.tar.gz
+        file:
+          - build/*.tar.gz
+          - docker-compose.yml
         skip_cleanup: true
         on:
           all_branches: true

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ You may also choose to manage the containers yourself with the `docker-compose.y
 
 ### Commands
 
+Go to the [releases page](https://github.com/src-d/superset-compose/releases) and download the `sandbox-ce` binary for your system. You will also need to download the `docker-compose.yml` file included in the release assets.
+
+Please make sure you run `sandbox-ce` commands in the same directory where you placed the `docker-compose.yml` file.
+
 #### Install
 
 ```
@@ -58,7 +62,7 @@ This will remove all containers and related resources such as network and volume
 
 ### Docker Compose
 
-As an alternative to `sandbox-ce` you can clone this repository and use the `docker-compose` command.
+As an alternative to `sandbox-ce` you can download the compose file and use the `docker-compose` command. Go to the [releases page](https://github.com/src-d/superset-compose/releases) to download the `docker-compose.yml` file included in the release assets.
 
 Before starting the containers, you will need to run the initialization script:
 


### PR DESCRIPTION
The binary included in the 0.0.1 needs to have the docker-compose file downloaded manually, but this is not documented.
The important part of this PR is the changes in the README. This is just a way to make the 0.0.1 release work

With the changes in this PR the docker-compose.yml file will be uploaded to the release assets. If this one is approved I'll update the 0.0.1 release manually with the compose file as it was in that tag.
This file upload on travis.conf is not an alternative to #13, I added just in case we want to release again before #13 is done.