### PR TITLE
Add restart policy to gitbase container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Add help messages to the `sandbox-ce` command ([#46](https://github.com/src-d/superset-compose/issues/46)).
 - `sandbox-ce install` now starts the containers on detached mode in the background ([#44](https://github.com/src-d/superset-compose/issues/44)).
 - New sub command `sandbox-ce web` to open the web UI in the browser ([#17](https://github.com/src-d/superset-compose/issues/17)).
+- Add `restart` policy to gitbase and bblfsh containers ([#63](https://github.com/src-d/superset-compose/issues/63)).
 
 #### Bug Fixes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     privileged: true
     ports:
       - 9432:9432
+    restart: always
 
   gitbase:
     image: srcd/gitbase:v0.20.0-beta4
@@ -21,6 +22,7 @@ services:
         read_only: true
         consistency: delegated
       - gitbase_indexes:/var/lib/gitbase/index
+    restart: always
 
   bblfsh-web:
     image: bblfsh/web:v0.11.0


### PR DESCRIPTION
Fix #61.

According to docs, [`deploy/restart_policy`](https://docs.docker.com/compose/compose-file/#restart_policy) only takes effect when deploying to a swarm with `docker stack deploy`, and is ignored by `docker-compose up`.

The closest thing we have is [`restart`](https://docs.docker.com/compose/compose-file/#restart).