### PR TITLE
Store compose files in workdirs inside ~/.srcd

### DIFF
--- a/cmd/sandbox-ce/cmd/install.go
+++ b/cmd/sandbox-ce/cmd/install.go
@@ -2,21 +2,73 @@ package cmd
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/src-d/superset-compose/cmd/sandbox-ce/compose"
 )
 
 type installCmd struct {
-	Command `name:"install" short-description:"Install and initialize containers" long-description:"Install, initialize, and start all the required docker containers, networks, volumes, and images."`
+	Command `name:"install" short-description:"Install and initialize containers" long-description:"Install, initialize, and start all the required docker containers, networks, volumes, and images.\n\nThe repos directory argument must point to a directory containing git repositories.\nIf it's not provided, the current working directory will be used."`
+
+	Args struct {
+		Reposdir string `positional-arg-name:"workdir"`
+	} `positional-args:"yes"`
 }
 
 func (c *installCmd) Execute(args []string) error {
+	reposdir, err := c.reposdirArg()
+	if err != nil {
+		return err
+	}
+
+	workdir, err := compose.InitWorkdir(reposdir)
+	if err != nil {
+		return err
+	}
+
+	// Before setting a new workdir, stop the current containers
+	compose.Run(context.Background(), "stop")
+
+	err = compose.SetActiveWorkdir(workdir)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("docker-compose working directory set to %s\n", workdir)
+
 	if err := compose.Run(context.Background(), "up", "--detach"); err != nil {
 		return err
 	}
 
 	return OpenUI(time.Minute)
+}
+
+func (c *installCmd) reposdirArg() (string, error) {
+	reposdir := c.Args.Reposdir
+	reposdir = strings.TrimSpace(reposdir)
+
+	var err error
+	if reposdir == "" {
+		reposdir, err = os.Getwd()
+	} else {
+		reposdir, err = filepath.Abs(reposdir)
+	}
+
+	if err != nil {
+		return "", errors.Wrap(err, "could not get directory")
+	}
+
+	info, err := os.Stat(reposdir)
+	if err != nil || !info.IsDir() {
+		return "", fmt.Errorf("path '%s' is not a valid directory", reposdir)
+	}
+
+	return reposdir, nil
 }
 
 func init() {

--- a/cmd/sandbox-ce/cmd/install.go
+++ b/cmd/sandbox-ce/cmd/install.go
@@ -8,8 +8,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/src-d/superset-compose/cmd/sandbox-ce/compose"
+	"github.com/src-d/superset-compose/cmd/sandbox-ce/compose/workdir"
+
+	"github.com/pkg/errors"
 )
 
 type installCmd struct {
@@ -26,7 +28,7 @@ func (c *installCmd) Execute(args []string) error {
 		return err
 	}
 
-	workdir, err := compose.InitWorkdir(reposdir)
+	dir, err := workdir.Init(reposdir)
 	if err != nil {
 		return err
 	}
@@ -34,12 +36,12 @@ func (c *installCmd) Execute(args []string) error {
 	// Before setting a new workdir, stop the current containers
 	compose.Run(context.Background(), "stop")
 
-	err = compose.SetActiveWorkdir(workdir)
+	err = workdir.SetActive(reposdir)
 	if err != nil {
 		return err
 	}
 
-	fmt.Printf("docker-compose working directory set to %s\n", workdir)
+	fmt.Printf("docker-compose working directory set to %s\n", dir)
 
 	if err := compose.Run(context.Background(), "up", "--detach"); err != nil {
 		return err

--- a/cmd/sandbox-ce/compose/compose.go
+++ b/cmd/sandbox-ce/compose/compose.go
@@ -2,8 +2,11 @@ package compose
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,6 +15,7 @@ import (
 
 	composefile "github.com/src-d/superset-compose/cmd/sandbox-ce/compose/file"
 	"github.com/src-d/superset-compose/cmd/sandbox-ce/dir"
+	datadir "github.com/src-d/superset-compose/cmd/sandbox-ce/dir"
 
 	"github.com/pkg/errors"
 )
@@ -22,10 +26,10 @@ const composeContainerURL = "https://github.com/docker/compose/releases/download
 
 var envKeys = []string{"GITBASE_REPOS_DIR"}
 
+const activeWorkdir = "__active__"
+
 type Compose struct {
-	bin    string
-	name   string
-	config string
+	bin string
 }
 
 func (c *Compose) Run(ctx context.Context, arg ...string) error {
@@ -34,8 +38,14 @@ func (c *Compose) Run(ctx context.Context, arg ...string) error {
 
 func (c *Compose) RunWithIO(ctx context.Context, stdin io.Reader,
 	stdout, stderr io.Writer, arg ...string) error {
-	arg = append([]string{"--file", c.config, "--project-name", c.name}, arg...)
 	cmd := exec.CommandContext(ctx, c.bin, arg...)
+
+	dir, err := workdirPath(activeWorkdir)
+	if err != nil {
+		return err
+	}
+
+	cmd.Dir = dir
 
 	var compOpts []string
 	for _, key := range envKeys {
@@ -62,9 +72,7 @@ func NewCompose() (*Compose, error) {
 		return nil, err
 	}
 
-	defaultFilePath, err := composefile.InitDefault()
-
-	return &Compose{bin: bin, name: "srcd", config: defaultFilePath}, nil
+	return &Compose{bin: bin}, nil
 }
 
 func getOrInstallComposeBinary() (string, error) {
@@ -140,4 +148,113 @@ func RunWithIO(ctx context.Context, stdin io.Reader, stdout, stderr io.Writer, a
 	}
 
 	return comp.RunWithIO(ctx, stdin, stdout, stderr, arg...)
+}
+
+// InitWorkdir creates a working directory in ~/.srcd for the given repositories
+// directory. The working directory will contain a docker-compose.yml and a
+// .env file.
+// If the directory is already initialized the function returns with no error
+func InitWorkdir(reposdir string) (string, error) {
+	defaultFilePath, err := composefile.InitDefault()
+	if err != nil {
+		return "", err
+	}
+
+	workdir, err := workdirPath(reposdir)
+	if err != nil {
+		return "", err
+	}
+
+	err = os.MkdirAll(workdir, 0755)
+	if err != nil {
+		return "", errors.Wrap(err, "could not create working directory")
+	}
+
+	composePath := filepath.Join(workdir, "docker-compose.yml")
+	_, err = os.Stat(composePath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return "", errors.Wrap(err, "could not read the existing docker-compose.yml file")
+		}
+
+		err = os.Symlink(defaultFilePath, composePath)
+		if err != nil {
+			return "", errors.Wrap(err, "could not create symlink to docker-compose.yml file")
+		}
+	}
+
+	envPath := filepath.Join(workdir, ".env")
+	emptyFile, err := isEmptyFile(envPath)
+	if err != nil {
+		return "", errors.Wrap(err, "could not read .env file contents")
+	}
+
+	if emptyFile {
+		hash := sha1.Sum([]byte(reposdir))
+		hashSt := hex.EncodeToString(hash[:])
+
+		contents := fmt.Sprintf(
+			`GITBASE_REPOS_DIR=%s
+COMPOSE_PROJECT_NAME=srcd-%s
+`,
+			reposdir, hashSt)
+
+		err = ioutil.WriteFile(envPath, []byte(contents), 0644)
+		if err != nil {
+			return "", errors.Wrap(err, "could not write .env file")
+		}
+	}
+
+	return workdir, nil
+}
+
+// isEmptyFile returns true if the file does not exist or if it exists but
+// contains empty text
+func isEmptyFile(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false, err
+		}
+
+		return true, nil
+	}
+
+	contents, err := ioutil.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+
+	strContents := string(contents)
+	return strings.TrimSpace(strContents) == "", nil
+}
+
+// SetActiveWorkdir creates a symlink from the fixed active workdir path
+// to the given workdir. The workdir should be the path returned by InitWorkdir
+func SetActiveWorkdir(workdir string) error {
+	dir, err := workdirPath(activeWorkdir)
+	if err != nil {
+		return err
+	}
+
+	_, err = os.Stat(dir)
+	if !os.IsNotExist(err) {
+		err = os.Remove(dir)
+		if err != nil {
+			return errors.Wrap(err, "could not delete the previous active workdir directory symlink")
+		}
+	}
+
+	return os.Symlink(workdir, dir)
+}
+
+// workdirPath returns the absolute path to
+// $HOME/.srcd/workdirs/reposdir
+func workdirPath(reposdir string) (string, error) {
+	path, err := datadir.Path()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(path, "workdirs", reposdir), nil
 }

--- a/cmd/sandbox-ce/compose/workdir/workdir.go
+++ b/cmd/sandbox-ce/compose/workdir/workdir.go
@@ -1,0 +1,140 @@
+// Package workdir provides functions to manage docker compose working
+// directories inside the $HOME/.srcd/workdirs directory
+package workdir
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	composefile "github.com/src-d/superset-compose/cmd/sandbox-ce/compose/file"
+	datadir "github.com/src-d/superset-compose/cmd/sandbox-ce/dir"
+
+	"github.com/pkg/errors"
+)
+
+const activeDir = "__active__"
+
+// Init creates a working directory in ~/.srcd for the given repositories
+// directory. The working directory will contain a docker-compose.yml and a
+// .env file.
+// If the directory is already initialized the function returns with no error.
+// The returned value is the absolute path to $HOME/.srcd/workdirs/reposdir
+func Init(reposdir string) (string, error) {
+	defaultFilePath, err := composefile.InitDefault()
+	if err != nil {
+		return "", err
+	}
+
+	workdir, err := path(reposdir)
+	if err != nil {
+		return "", err
+	}
+
+	err = os.MkdirAll(workdir, 0755)
+	if err != nil {
+		return "", errors.Wrap(err, "could not create working directory")
+	}
+
+	composePath := filepath.Join(workdir, "docker-compose.yml")
+	_, err = os.Stat(composePath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return "", errors.Wrap(err, "could not read the existing docker-compose.yml file")
+		}
+
+		err = os.Symlink(defaultFilePath, composePath)
+		if err != nil {
+			return "", errors.Wrap(err, "could not create symlink to docker-compose.yml file")
+		}
+	}
+
+	envPath := filepath.Join(workdir, ".env")
+	emptyFile, err := isEmptyFile(envPath)
+	if err != nil {
+		return "", errors.Wrap(err, "could not read .env file contents")
+	}
+
+	if emptyFile {
+		hash := sha1.Sum([]byte(reposdir))
+		hashSt := hex.EncodeToString(hash[:])
+
+		contents := fmt.Sprintf(
+			`GITBASE_REPOS_DIR=%s
+COMPOSE_PROJECT_NAME=srcd-%s
+`,
+			reposdir, hashSt)
+
+		err = ioutil.WriteFile(envPath, []byte(contents), 0644)
+		if err != nil {
+			return "", errors.Wrap(err, "could not write .env file")
+		}
+	}
+
+	return workdir, nil
+}
+
+// isEmptyFile returns true if the file does not exist or if it exists but
+// contains empty text
+func isEmptyFile(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false, err
+		}
+
+		return true, nil
+	}
+
+	contents, err := ioutil.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+
+	strContents := string(contents)
+	return strings.TrimSpace(strContents) == "", nil
+}
+
+// SetActive creates a symlink from the fixed active workdir path
+// to the workdir for the given repos dir.
+func SetActive(reposdir string) error {
+	dir, err := path(activeDir)
+	if err != nil {
+		return err
+	}
+
+	workdir, err := path(reposdir)
+	if err != nil {
+		return err
+	}
+
+	_, err = os.Stat(dir)
+	if !os.IsNotExist(err) {
+		err = os.Remove(dir)
+		if err != nil {
+			return errors.Wrap(err, "could not delete the previous active workdir directory symlink")
+		}
+	}
+
+	return os.Symlink(workdir, dir)
+}
+
+// Active returns th absolute path to $HOME/.srcd/workdirs/__active__
+func Active() (string, error) {
+	return path(activeDir)
+}
+
+// path returns the absolute path to
+// $HOME/.srcd/workdirs/reposdir
+func path(reposdir string) (string, error) {
+	path, err := datadir.Path()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(path, "workdirs", reposdir), nil
+}


### PR DESCRIPTION
Part of #15.

This is my proposal to handle multiple deployments for different sets of repositories.

This should give you a good picture of the idea:
```
$ sandbox-ce install ~/go/src/github.com/src-d/
$ sandbox-ce install ~/repos

$ tree -a ~/.srcd/
/home/cmartin/.srcd/
├── docker-compose.yml
└── workdirs
    ├── __active__ -> /home/cmartin/.srcd/workdirs/home/cmartin/repos
    └── home
        └── cmartin
            ├── go
            │   └── src
            │       └── github.com
            │           └── src-d
            │               ├── docker-compose.yml -> /home/cmartin/.srcd/docker-compose.yml
            │               └── .env
            └── repos
                ├── docker-compose.yml -> /home/cmartin/.srcd/docker-compose.yml
                └── .env

$ pwd
/home/cmartin/.srcd/workdirs/__active__

$ cat .env 
GITBASE_REPOS_DIR=/home/cmartin/repos
COMPOSE_PROJECT_NAME=srcd-4c901c8fd0b755feb1470a91dc59d50d806c748b

$ docker-compose ps
                           Name                                         Command                  State               Ports         
-----------------------------------------------------------------------------------------------------------------------------------
srcd-4c901c8fd0b755feb1470a91dc59d50d806c748b_bblfsh-web_1   /bin/bblfsh-web -addr :808 ...   Up             0.0.0.0:9999->8080/tcp
srcd-4c901c8fd0b755feb1470a91dc59d50d806c748b_bblfsh_1       bblfshd                          Up             0.0.0.0:9432->9432/tcp
srcd-4c901c8fd0b755feb1470a91dc59d50d806c748b_gitbase_1      ./init.sh                        Up             0.0.0.0:3306->3306/tcp
srcd-4c901c8fd0b755feb1470a91dc59d50d806c748b_postgres_1     docker-entrypoint.sh postgres    Up             0.0.0.0:5432->5432/tcp
srcd-4c901c8fd0b755feb1470a91dc59d50d806c748b_redis_1        docker-entrypoint.sh redis ...   Up             0.0.0.0:6379->6379/tcp
srcd-4c901c8fd0b755feb1470a91dc59d50d806c748b_superset_1     /entrypoint.sh                   Up (healthy)   0.0.0.0:8088->8088/tcp

$ docker volume ls
DRIVER              VOLUME NAME
local               srcd-4c901c8fd0b755feb1470a91dc59d50d806c748b_postgres
local               srcd-4c901c8fd0b755feb1470a91dc59d50d806c748b_redis
local               srcd-ef2f6172f3165cd61fdcfc765ac9440610d2dbb5_postgres
local               srcd-ef2f6172f3165cd61fdcfc765ac9440610d2dbb5_redis
```

Key docker compose behaviours leveraged in this PR:
- Docker compose already handles different deployments isolation with the `project name`
- This project name by default is the docker-compose.yml dir name. It can be also set with COMPOSE_PROJECT_NAME
- docker-compose will read env vars from a `.env` file. This file needs to be in the current working directory. This means `docker-compose -f /tmp/docker-compose.yml` will ignore `/tmp/.env` unless your current dir is `/tmp`.

The isolation happens because each dir in `.srcd/workdirs` contains a unique COMPOSE_PROJECT_NAME made with the full path sha1.

The sha1 makes the docker names ugly, and hard to relate to some specific folder. But the full name must be used to create the project name, otherwise `~/repos` and `~/other/path/repos` would share the `repos` project name. Another alternative might be to use the full path in clear, but something like `srcd-home_cmartin_repos_postgres` is also a bit awkward to manage, as it can grow to a very long name.

Each dir could be placed as a first level sub dir of `.srcd/workdirs`, using `.srcd/workdirs/<sha1>`. But I think having the full folder hierarchy replicated in `.srcd/workdirs`  makes it intuitive for advanced users to just `cd ~/.srcd/workdirs/` and understand what is going on.

From any of the directories there you can run any `docker-compose` commands without any extra requirements. No env vars to set, no extra options like `--file`.

All the `docker-compose.yml` files are symbolic links. So when the mechanism to download newer compose files is in place we will not have to update anything in each workdir.

If you try it out you'll see that `install` will prompt you to create the admin user even when you use a dir that was already initialized. This will be solved in #48.

I didn't write any docs or changelog because I wanted your feedback on it first.

Also there are missing details that I think are better addressed in future PR, and also make sense to include in future releases.
- Handle empty `.srcd` when other commands are executed before `install`
```
$ rm -rf ~/.srcd
$ sandbox-ce stop
chdir /home/cmartin/.srcd/workdirs/__active__: no such file or directory
```
- List all the existing workdirs. This can be also useful to `prune` everything done by `sandbox-ce`, not just the current `__active__` volumes.
- Consider a rename of the command. `install` is fine for the first time you run the sandobx. But as a command to come back to a dir that was used previously, maybe `init` would be more intuitive. Or `up`, to make it clear that it's the equivalent of `docker-compose up`