### PR TITLE
Add a placeholder welcome dashboard on bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
 
 - The gitbase indexes are now persistent ([#65](https://github.com/src-d/superset-compose/issues/65)).
 
+### `srcd/superset` Docker Image
+
+#### New Features
+
+- Loading of default dashboards on bootstrap ([#71](https://github.com/src-d/superset-compose/issues/71)).
+
 </details>
 
 ## [v0.0.1](https://github.com/src-d/superset-compose/releases/tag/v0.0.1) - 2019-05-16
@@ -30,7 +36,7 @@ Initial release. It includes a `sandbox-ce` command with the sub commands `insta
 
 This binary is a wrapper for Docker Compose, and requires you to download the `docker-compose.yml` file from this repository.
 
-### `srcd/superset` docker image
+### `srcd/superset` Docker Image
 
 The `srcd/superset` docker image is based on Superset 0.32, and contains the following additions:
 - an extra tab, UAST, to explore bblfsh parsing results.

--- a/srcd/dashboards/README.md
+++ b/srcd/dashboards/README.md
@@ -1,0 +1,7 @@
+The dashboards placed here will be included in Superset on bootstrap.
+
+You can export Superset dashboards with the `superset` command included in the docker image. For example:
+
+```shell
+docker-compose exec superset superset export_dashboards > /dashboards.json
+```

--- a/srcd/dashboards/placeholder.json
+++ b/srcd/dashboards/placeholder.json
@@ -1,0 +1,182 @@
+{
+  "dashboards": [
+    {
+      "__Dashboard__": {
+        "changed_by_fk": 1,
+        "slug": null,
+        "css": "",
+        "position_json": "{\"CHART-bludb6lGd_\":{\"children\":[],\"id\":\"CHART-bludb6lGd_\",\"meta\":{\"chartId\":1,\"height\":51,\"sliceName\":\"Repositories\",\"width\":6},\"type\":\"CHART\"},\"DASHBOARD_VERSION_KEY\":\"v2\",\"GRID_ID\":{\"children\":[\"ROW-N5UuVDakww\"],\"id\":\"GRID_ID\",\"type\":\"GRID\"},\"HEADER_ID\":{\"id\":\"HEADER_ID\",\"meta\":{\"text\":\"Welcome\"},\"type\":\"HEADER\"},\"ROOT_ID\":{\"children\":[\"GRID_ID\"],\"id\":\"ROOT_ID\",\"type\":\"ROOT\"},\"ROW-N5UuVDakww\":{\"children\":[\"CHART-bludb6lGd_\"],\"id\":\"ROW-N5UuVDakww\",\"meta\":{\"background\":\"BACKGROUND_TRANSPARENT\"},\"type\":\"ROW\"}}",
+        "id": 1,
+        "changed_on": {
+          "__datetime__": "2019-05-24T16:06:01"
+        },
+        "created_by_fk": 1,
+        "json_metadata": "{\"filter_immune_slices\": [], \"timed_refresh_immune_slices\": [], \"filter_immune_slice_fields\": {}, \"expanded_slices\": {}, \"default_filters\": \"{}\", \"remote_id\": 1}",
+        "description": null,
+        "dashboard_title": "Welcome",
+        "created_on": {
+          "__datetime__": "2019-05-24T16:03:48"
+        },
+        "slices": [
+          {
+            "__Slice__": {
+              "params": "{\"adhoc_filters\": [], \"align_pn\": false, \"all_columns\": [\"repository_id\"], \"color_pn\": true, \"datasource\": \"10__table\", \"granularity_sqla\": null, \"groupby\": [], \"include_search\": false, \"include_time\": false, \"metrics\": [], \"order_by_cols\": [], \"order_desc\": true, \"page_length\": 0, \"percent_metrics\": [], \"row_limit\": 10000, \"table_filter\": false, \"table_timestamp_format\": \"%Y-%m-%d %H:%M:%S\", \"time_grain_sqla\": \"P1D\", \"time_range\": \"Last week\", \"timeseries_limit_metric\": null, \"url_params\": {}, \"viz_type\": \"table\", \"remote_id\": 1, \"datasource_name\": \"gitbase.repositories\", \"schema\": \"gitbase.repositories\", \"database_name\": \"gitbase\"}",
+              "datasource_name": "gitbase.repositories",
+              "datasource_id": 10,
+              "id": 1,
+              "created_on": {
+                "__datetime__": "2019-05-24T16:04:55"
+              },
+              "changed_by_fk": 1,
+              "perm": "[gitbase].[gitbase.repositories](id:10)",
+              "description": null,
+              "viz_type": "table",
+              "datasource_type": "table",
+              "slice_name": "Repositories",
+              "changed_on": {
+                "__datetime__": "2019-05-24T16:07:09"
+              },
+              "created_by_fk": 1,
+              "cache_timeout": null,
+              "owners": [
+                {
+                  "__User__": {
+                    "active": true,
+                    "changed_by_fk": null,
+                    "email": "admin@fab.org",
+                    "last_login": null,
+                    "login_count": null,
+                    "id": 1,
+                    "fail_login_count": null,
+                    "first_name": "admin",
+                    "created_on": {
+                      "__datetime__": "2019-05-24T16:03:07"
+                    },
+                    "last_name": "user",
+                    "changed_on": {
+                      "__datetime__": "2019-05-24T16:03:07"
+                    },
+                    "username": "admin",
+                    "created_by_fk": null,
+                    "password": "pbkdf2:sha256:50000$EXV9oBSR$95644dce243cd70e1042ac9b06706694e402422ed89a7005b67fbac3900a7e28"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "datasources": [
+    {
+      "__SqlaTable__": {
+        "default_endpoint": null,
+        "changed_by_fk": null,
+        "main_dttm_col": null,
+        "is_featured": false,
+        "database_id": 2,
+        "filter_select_enabled": false,
+        "fetch_values_predicate": null,
+        "offset": 0,
+        "schema": null,
+        "cache_timeout": null,
+        "created_on": {
+          "__datetime__": "2019-05-24T16:03:21"
+        },
+        "sql": "select * from repositories",
+        "params": "{\"remote_id\": 10, \"database_name\": \"gitbase\"}",
+        "changed_on": {
+          "__datetime__": "2019-05-24T16:03:21"
+        },
+        "is_sqllab_view": false,
+        "perm": "[gitbase].[gitbase.repositories](id:10)",
+        "id": 10,
+        "template_params": null,
+        "table_name": "gitbase.repositories",
+        "description": null,
+        "created_by_fk": null,
+        "database": {
+          "__Database__": {
+            "allow_multi_schema_metadata_fetch": false,
+            "cache_timeout": null,
+            "created_on": {
+              "__datetime__": "2019-05-24T16:03:20"
+            },
+            "extra": "{\n    \"metadata_params\": {},\n    \"engine_params\": {},\n    \"metadata_cache_timeout\": {},\n    \"schemas_allowed_for_csv_upload\": []\n}\n",
+            "select_as_create_table_as": false,
+            "perm": "[gitbase].(id:2)",
+            "changed_on": {
+              "__datetime__": "2019-05-24T16:03:20"
+            },
+            "expose_in_sqllab": true,
+            "id": 2,
+            "impersonate_user": false,
+            "allow_run_async": true,
+            "verbose_name": null,
+            "created_by_fk": null,
+            "allow_csv_upload": false,
+            "database_name": "gitbase",
+            "changed_by_fk": null,
+            "allow_ctas": false,
+            "sqlalchemy_uri": "mysql://root@gitbase:3306/gitbase",
+            "allow_dml": true,
+            "password": "",
+            "force_ctas_schema": null
+          }
+        },
+        "metrics": [
+          {
+            "__SqlMetric__": {
+              "id": 10,
+              "created_on": {
+                "__datetime__": "2019-05-24T16:03:21"
+              },
+              "created_by_fk": null,
+              "table_id": 10,
+              "warning_text": null,
+              "is_restricted": false,
+              "metric_type": "count",
+              "metric_name": "count",
+              "changed_on": {
+                "__datetime__": "2019-05-24T16:03:21"
+              },
+              "changed_by_fk": null,
+              "expression": "COUNT(*)",
+              "d3format": null,
+              "description": null,
+              "verbose_name": "COUNT(*)"
+            }
+          }
+        ],
+        "columns": [
+          {
+            "__TableColumn__": {
+              "column_name": "repository_id",
+              "changed_on": {
+                "__datetime__": "2019-05-24T16:03:21"
+              },
+              "created_by_fk": null,
+              "python_date_format": null,
+              "is_dttm": false,
+              "table_id": 10,
+              "filterable": false,
+              "type": "TEXT",
+              "verbose_name": null,
+              "id": 47,
+              "changed_by_fk": null,
+              "created_on": {
+                "__datetime__": "2019-05-24T16:03:21"
+              },
+              "expression": "",
+              "database_expression": null,
+              "description": null,
+              "groupby": false,
+              "is_active": true
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/superset/contrib/docker/Dockerfile
+++ b/superset/contrib/docker/Dockerfile
@@ -51,6 +51,7 @@ RUN pip install --upgrade setuptools pip \
     && rm -rf /root/.cache/pip
 
 COPY --chown=superset:superset superset superset
+COPY --chown=superset:superset dashboards dashboards
 
 ENV PATH=/home/superset/superset/bin:$PATH \
     PYTHONPATH=/home/superset/:$PYTHONPATH \

--- a/superset/contrib/docker/docker-init.sh
+++ b/superset/contrib/docker/docker-init.sh
@@ -33,3 +33,6 @@ superset init
 
 # Add gitbase
 python add_gitbase.py
+
+# Add dashboards
+superset import_dashboards --recursive --path /home/superset/dashboards


### PR DESCRIPTION
Fix #71.

This PR adds the mechanism to include dashboards on bootstrap.

I added a very basic dashboard that is supposed to be removed as soon as we have better ones. But for now it's enough to verify that the sandbox started correctly and loaded the intended repositories.

I found out that the export from the CLI, `superset export_dashboards`, is much less verbose than the json exported from the UI. So I included a small README on how to use it.

Even though the json includes all the owner info, I tested to bootstrap with different username and password, and it worked fine. Probably the `owner/id` is the only relevant field.

![image](https://user-images.githubusercontent.com/1469173/58344676-3ef05f00-7e4e-11e9-8d39-236884bed84b.png)
