### PR TITLE
use sparksql instead of mysql for enterprise version

### DIFF
--- a/superset/contrib/docker/superset_config.py
+++ b/superset/contrib/docker/superset_config.py
@@ -70,16 +70,19 @@ CELERY_CONFIG = CeleryConfig
 
 # Gitbase configuration
 
+IS_EE = get_env_variable('MODE', 'Community') == 'Enterprise'
 GITBASE_USER = get_env_variable('GITBASE_USER')
 GITBASE_PASSWORD = get_env_variable('GITBASE_PASSWORD', '')
 GITBASE_HOST = get_env_variable('GITBASE_HOST')
 GITBASE_PORT = get_env_variable('GITBASE_PORT')
 GITBASE_DB = get_env_variable('GITBASE_DB')
-GITBASE_DATABASE_URI = 'mysql://%s:%s@%s:%s/%s' % (GITBASE_USER,
-                                                   GITBASE_PASSWORD,
-                                                   GITBASE_HOST,
-                                                   GITBASE_PORT,
-                                                   GITBASE_DB)
+GITBASE_PREFIX = 'sparksql' if IS_EE else 'mysql'
+GITBASE_DATABASE_URI = '%s://%s:%s@%s:%s/%s' % (GITBASE_PREFIX,
+                                                GITBASE_USER,
+                                                GITBASE_PASSWORD,
+                                                GITBASE_HOST,
+                                                GITBASE_PORT,
+                                                GITBASE_DB)
 
 SQLLAB_DEFAULT_DBID = 2  # set gitbase as default DB in SQL Lab
 


### PR DESCRIPTION
New optional environmental variable MODE set into Enterprise switches
connection string prefix to sparksql.

I didn't added variable into docker-compose and also didn't add docs because it's not clear for me if we should document EE publicly or not.