### PR TITLE
Fix mariadb issue

### DIFF
--- a/superset/contrib/docker/Dockerfile
+++ b/superset/contrib/docker/Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get update -y
 # Install git as it is used for requirements from Github
 RUN apt-get install -y git
 # Install superset dependencies
-RUN apt-get install -y libsasl2-dev libsasl2-2 libsasl2-modules-gssapi-mit
+RUN apt-get install -y libsasl2-dev libsasl2-2 libsasl2-modules-gssapi-mit libmariadb3
 
 RUN if [ "$DEV_BUILD" = "true" ]; \
         then apt-get install -y curl && \


### PR DESCRIPTION
Install `libmariadb3` on image to avoid
```shell
ERROR [root] libmariadbclient.so.18: cannot open shared object file: No such file or directory
```

as reported by slack:
if I do:
```shell
$ GO111MODULE=on go install ./cmd/sourced
$ sourced version
sourced version master build dev
$ sourced compose version
$ docker rmi srcd/sourced-ui :v0.5.0
$ VERSION=v0.5.0 make build
$ sourced init local .
```

and check source{d} CE status, I see that sourced-ui is in a restart loop, logging this:
```shell
ERROR [root] libmariadbclient.so.18: cannot open shared object file: No such file or directory
Traceback (most recent call last):
  File "/home/superset/superset/models/core.py", line 1092, in get_all_table_names_in_schema
    inspector=self.inspector, schema=schema
  File "/home/superset/superset/models/core.py", line 1040, in inspector
    engine = self.get_sqla_engine()
  File "/home/superset/superset/utils/core.py", line 134, in __call__
    value = self.func(*args, **kwargs)
  File "/home/superset/superset/models/core.py", line 937, in get_sqla_engine
    return create_engine(url, **params)
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/engine/__init__.py", line 435, in create_engine
    return strategy.create(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/engine/strategies.py", line 87, in create
    dbapi = dialect_cls.dbapi(**dbapi_args)
  File "/usr/local/lib/python3.6/site-packages/sqlalchemy/dialects/mysql/mysqldb.py", line 118, in dbapi
    return __import__("MySQLdb")
  File "/usr/local/lib/python3.6/site-packages/MySQLdb/__init__.py", line 18, in <module>
    from . import _mysql
ImportError: libmariadbclient.so.18: cannot open shared object file: No such file or directory
Loaded your LOCAL configuration at [/home/superset/superset/superset_config.py]
Traceback (most recent call last):
  File "bootstrap.py", line 122, in <module>
    bootstrap()
  File "bootstrap.py", line 79, in bootstrap
    create_datasource_tables(dbobj, conf.get('GITBASE_DB'))
  File "bootstrap.py", line 30, in create_datasource_tables
    for ds in dbobj.get_all_table_names_in_schema(schema):
TypeError: 'NoneType' object is not iterable
```

---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [ ] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [x] This PR contains changes that do not require a mention in the CHANGELOG file
