### PR TITLE
Delete patched elements, when deleted from srcd

### DIFF
--- a/watcher
+++ b/watcher
@@ -10,15 +10,37 @@ function ctrl_c {
 }
 
 function watch_inotify {
-  inotifywait --recursive \
-    --event modify,move,create,delete \
-    $DIRECTORY_TO_OBSERVE
+  inotifywait --recursive --monitor --quiet \
+    --event modify,move,create,delete,attrib \
+    ${DIRECTORY_TO_OBSERVE} | awk -v SRCD="^srcd" -v SUPERSET="$(pwd)/superset" '{ \
+      print $0; \
+      if ($2 ~ "DELETE" || $2 ~ "MOVED_FROM") { \
+        print "[deleted]: " $1$3; \
+        print "rm -rf " gensub(SRCD, SUPERSET, 1, $1$3); \
+        system("rm -rf " gensub(SRCD, SUPERSET, 1, $1$3)); \
+      } else { \
+        print "[modified]: " $1$3; \
+        system("make --no-print-directory apply-patch"); \
+      } \
+    }';
 }
 
 function watch_fswatch {
-  fswatch --recursive --one-event \
-    --event Created --event Updated --event Removed \
-    ${DIRECTORY_TO_OBSERVE}
+  fswatch --recursive --event-flags \
+    --event Created --event Updated --event Removed --event Renamed \
+    --event MovedFrom --event MovedTo \
+    --event OwnerModified --event AttributeModified \
+    ${DIRECTORY_TO_OBSERVE} | awk -v SRCD="$(pwd)/srcd" -v SUPERSET="$(pwd)/superset" '{ \
+      print $0; \
+      if ($2 ~ "Removed") { \
+        print "[deleted]: " $1; \
+        print "rm -rf " gensub(SRCD, SUPERSET, 1, $1); \
+        system("rm -rf " gensub(SRCD, SUPERSET, 1, $1)); \
+      } else { \
+        print "[modified]: " $1; \
+        system("make --no-print-directory apply-patch"); \
+      } \
+    }';
 }
 
 
@@ -43,6 +65,5 @@ fi
 
 make --no-print-directory apply-patch
 echo -e "\033[1;92mWatching for changes in 'srcd'; using '${whichWatcher}' ...\033[0m"
-while watcher; do
-  make --no-print-directory apply-patch
-done
+
+watcher

--- a/watcher
+++ b/watcher
@@ -18,7 +18,11 @@ function watch_inotify {
         print "[deleted]: " $1$3; \
         print "rm -rf " gensub(SRCD, SUPERSET, 1, $1$3); \
         system("rm -rf " gensub(SRCD, SUPERSET, 1, $1$3)); \
-      } else { \
+      } else if ($1$3 ~ "docker-compose.override.yml") { \
+        print "[docker-compose.override]: updated " $1$3; \
+        system("cp -rf " $1$3 " ~/.sourced/compose-files/__active__/docker-compose.override.yml"); \
+      } \
+      else { \
         print "[modified]: " $1$3; \
         system("make --no-print-directory apply-patch"); \
       } \
@@ -36,7 +40,11 @@ function watch_fswatch {
         print "[deleted]: " $1; \
         print "rm -rf " gensub(SRCD, SUPERSET, 1, $1); \
         system("rm -rf " gensub(SRCD, SUPERSET, 1, $1)); \
-      } else { \
+      } else if ($1 ~ "docker-compose.override.yml") { \
+        print "[docker-compose.override]: updated " $1; \
+        system("cp -rf " $1 " ~/.sourced/compose-files/__active__/docker-compose.override.yml"); \
+      } \
+      else { \
         print "[modified]: " $1; \
         system("make --no-print-directory apply-patch"); \
       } \


### PR DESCRIPTION
fix #225
blocks https://github.com/src-d/sourced-ui/pull/320

When in development it is used `make dev-prepare`, the content of `srcd` is copied into `sourced` and a watcher is coping it again every time one file from `srcd` is updated.
Now:
- it listens for deletions, renames, and moves.
- it now updates the `docker-compose.override.yml` from `~/.sourced/compose-files/__active__` when `srcd/contrib/docker/docker-compose.override.yml` changes.

---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [ ] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [x] This PR contains changes that do not require a mention in the CHANGELOG file
