### PR TITLE
Fix entrypoint in sourced-ui-celery for dev

### DIFF
--- a/srcd/contrib/docker/docker-compose.override.yml
+++ b/srcd/contrib/docker/docker-compose.override.yml
@@ -22,8 +22,7 @@ services:
   sourced-ui-celery:
     # disable separate celery container
     image: tianon/true
-    entrypoint: 'true'
-    command: 'true'
+    entrypoint: /true
 
 volumes:
   node_modules:


### PR DESCRIPTION
When I tried the dev mode, I got:
```shell
$ sourced init local .
docker-compose working directory set to ~/.sourced/workdirs/local/L3Byb2plY3RzL3NyYy9naXRodWIuY29tL3NyYy1kL3NvdXJjZWQtY2U
[...]
Creating srcd-ymjsznno_sourced-ui-celery_1 ... error
[...]
ERROR: for sourced-ui-celery  Cannot start service sourced-ui-celery:
    OCI runtime create failed: container_linux.go:345:
    starting container process caused "exec: \"true\":
    executable file not found in $PATH": unknown
ERROR: Encountered errors while bringing up the project.
exit status 1
```

If I'm not wrong, `true` binary would be [only accessible from `/true`](https://github.com/tianon/dockerfiles/blob/master/true/Dockerfile#L2)

---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [ ] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [x] This PR contains changes that do not require a mention in the CHANGELOG file
