### PR TITLE
Disable restart policy on celery when running dev mode

### DIFF
--- a/srcd/contrib/docker/docker-compose.override.yml
+++ b/srcd/contrib/docker/docker-compose.override.yml
@@ -21,6 +21,7 @@ services:
 
   sourced-ui-celery:
     # disable separate celery container
+    restart: \"no\"
     image: tianon/true
     entrypoint: /true
 


### PR DESCRIPTION
related to https://github.com/src-d/sourced-ui/pull/317
blocks https://github.com/src-d/sourced-ui/pull/320

Since `sourced-ui-celery` in dev mode is replaced by `tianon/true`, which exits fast, the restart policy should be `"no"` in order to avoid entering in a restart loop.

The `\"no\"` needs to be escaped because it must be a "string", and otherwise, the quotes (`"`) would be removed by [`awk` when processing the `docker-compose.override.yml` template](https://github.com/src-d/sourced-ui/blob/master/Makefile#L77).





---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [ ] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [x] This PR contains changes that do not require a mention in the CHANGELOG file
