### PR TITLE
OAuth GitHub support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Support for GitHub OAuth authorization ([#320](https://github.com/src-d/sourced-ui/issues/320))
+
 ## [v0.8.1](https://github.com/src-d/sourced-ui/releases/tag/v0.8.1) - 2019-10-28
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -51,10 +51,12 @@ You can configure the Docker image using the following environment variables:
 | `METADATA_USER`           | Username for metadata DB (when `SYNC_MODE` is set to `true`)            |
 | `METADATA_PASSWORD`       | Password for metadata DB (when `SYNC_MODE` is set to `true`)            |
 | `METADATA_DB`             | Database name for metadata (when `SYNC_MODE` is set to `true`)          |
-| `OAUTH_PROVIDER`          | Use OAuth provider for authorization. Currently only `google`           |
-| `OAUTH_CONSUMER_KEY`      | OAuth provider consumer key (aka client_id)                             |
-| `OAUTH_CONSUMER_SECRET`   | OAuth provider consumer secret (aka client_secret)                      |
+| `OAUTH_ENABLED_PROVIDERS` | Comma separated list of available OAuth providers (eg: `github,google`) |
 | `OAUTH_REGISTRATION_ROLE` | The role for newly registered users using OAuth `Admin`/`Alpha`/`Gamma` |
+| `OAUTH_GITHUB_CONSUMER_KEY`    | GitHub OAuth provider consumer key (aka client_id)                 |
+| `OAUTH_GITHUB_CONSUMER_SECRET` | GitHub OAuth provider consumer secret (aka client_secret)          |
+| `OAUTH_GOOGLE_CONSUMER_KEY`    | Google OAuth provider consumer key (aka client_id)                 |
+| `OAUTH_GOOGLE_CONSUMER_SECRET` | Google OAuth provider consumer secret (aka client_secret)          |
 
 To see the differences between roles in `OAUTH_REGISTRATION_ROLE` variable consult [official superset documentation](https://superset.incubator.apache.org/security.html#provided-roles).
 

--- a/srcd/contrib/docker/docker-compose.override.yml
+++ b/srcd/contrib/docker/docker-compose.override.yml
@@ -21,6 +21,7 @@ services:
 
   sourced-ui-celery:
     # disable separate celery container
+    restart: \"no\"
     image: tianon/true
     entrypoint: /true
 

--- a/srcd/contrib/docker/docker-compose.override.yml
+++ b/srcd/contrib/docker/docker-compose.override.yml
@@ -12,6 +12,7 @@ services:
       - ${SOURCED_UI_ABS_PATH}/superset/dashboards:/home/superset/dashboards
       - ${SOURCED_UI_ABS_PATH}/superset/contrib/docker/superset_config.py:/home/superset/superset/superset_config.py
       - ${SOURCED_UI_ABS_PATH}/superset/contrib/docker/docker-entrypoint.sh:/entrypoint.sh
+      - ${SOURCED_UI_ABS_PATH}/superset/contrib/docker/bootstrap.py:/home/superset/bootstrap.py
       - type: volume
         source: node_modules
         target: /home/superset/superset/assets/node_modules

--- a/superset/contrib/docker/docker-entrypoint.sh
+++ b/superset/contrib/docker/docker-entrypoint.sh
@@ -45,7 +45,7 @@ elif [ "$SUPERSET_ENV" = "development" ]; then
     # non-asset requests to `Flask`, wich is listening at the port 8081
     # Doing so, updates to asset sources will be reflected in-browser without a refresh.
     (cd superset/assets/ && npm install)
-    (cd superset/assets/ && npm run dev-server -- --host=0.0.0.0 --port=8088 --supersetPort=8081) &
+    (cd superset/assets/ && npm run dev-server -- --host=0.0.0.0 --port=8088 --supersetPort=8081 --disable-host-check) &
     FLASK_ENV=development FLASK_APP=superset:app flask run -p 8081 --with-threads --reload --debugger --host=0.0.0.0
 elif [ "$SUPERSET_ENV" = "production" ]; then
     exec gunicorn --bind 0.0.0.0:8088 \

--- a/superset/contrib/docker/docker-entrypoint.sh
+++ b/superset/contrib/docker/docker-entrypoint.sh
@@ -23,6 +23,7 @@ if [ "`whoami`" = "root" ] && [ -n "$LOCAL_USER" ]; then
     # It will grant write access to the data from the volumes,
     # inside of the container and on host file system (see #221)
     find . -group superset -exec chgrp $LOCAL_USER '{}' \;
+    find . -group root -exec chgrp $LOCAL_USER '{}' \;
     groupmod -g $LOCAL_USER superset
     usermod -u $LOCAL_USER superset
     chown -R superset superset/assets/node_modules

--- a/watcher
+++ b/watcher
@@ -10,15 +10,37 @@ function ctrl_c {
 }
 
 function watch_inotify {
-  inotifywait --recursive \
-    --event modify,move,create,delete \
-    $DIRECTORY_TO_OBSERVE
+  inotifywait --recursive --monitor --quiet \
+    --event modify,move,create,delete,attrib \
+    ${DIRECTORY_TO_OBSERVE} | awk -v SRCD="^srcd" -v SUPERSET="$(pwd)/superset" '{ \
+      print $0; \
+      if ($2 ~ "DELETE" || $2 ~ "MOVED_FROM") { \
+        print "[deleted]: " $1$3; \
+        print "rm -rf " gensub(SRCD, SUPERSET, 1, $1$3); \
+        system("rm -rf " gensub(SRCD, SUPERSET, 1, $1$3)); \
+      } else { \
+        print "[modified]: " $1$3; \
+        system("make --no-print-directory apply-patch"); \
+      } \
+    }';
 }
 
 function watch_fswatch {
-  fswatch --recursive --one-event \
-    --event Created --event Updated --event Removed \
-    ${DIRECTORY_TO_OBSERVE}
+  fswatch --recursive --event-flags \
+    --event Created --event Updated --event Removed --event Renamed \
+    --event MovedFrom --event MovedTo \
+    --event OwnerModified --event AttributeModified \
+    ${DIRECTORY_TO_OBSERVE} | awk -v SRCD="$(pwd)/srcd" -v SUPERSET="$(pwd)/superset" '{ \
+      print $0; \
+      if ($2 ~ "Removed") { \
+        print "[deleted]: " $1; \
+        print "rm -rf " gensub(SRCD, SUPERSET, 1, $1); \
+        system("rm -rf " gensub(SRCD, SUPERSET, 1, $1)); \
+      } else { \
+        print "[modified]: " $1; \
+        system("make --no-print-directory apply-patch"); \
+      } \
+    }';
 }
 
 
@@ -43,6 +65,5 @@ fi
 
 make --no-print-directory apply-patch
 echo -e "\033[1;92mWatching for changes in 'srcd'; using '${whichWatcher}' ...\033[0m"
-while watcher; do
-  make --no-print-directory apply-patch
-done
+
+watcher

--- a/watcher
+++ b/watcher
@@ -18,7 +18,11 @@ function watch_inotify {
         print "[deleted]: " $1$3; \
         print "rm -rf " gensub(SRCD, SUPERSET, 1, $1$3); \
         system("rm -rf " gensub(SRCD, SUPERSET, 1, $1$3)); \
-      } else { \
+      } else if ($1$3 ~ "docker-compose.override.yml") { \
+        print "[docker-compose.override]: updated " $1$3; \
+        system("cp -rf " $1$3 " ~/.sourced/compose-files/__active__/docker-compose.override.yml"); \
+      } \
+      else { \
         print "[modified]: " $1$3; \
         system("make --no-print-directory apply-patch"); \
       } \
@@ -36,7 +40,11 @@ function watch_fswatch {
         print "[deleted]: " $1; \
         print "rm -rf " gensub(SRCD, SUPERSET, 1, $1); \
         system("rm -rf " gensub(SRCD, SUPERSET, 1, $1)); \
-      } else { \
+      } else if ($1 ~ "docker-compose.override.yml") { \
+        print "[docker-compose.override]: updated " $1; \
+        system("cp -rf " $1 " ~/.sourced/compose-files/__active__/docker-compose.override.yml"); \
+      } \
+      else { \
         print "[modified]: " $1; \
         system("make --no-print-directory apply-patch"); \
       } \


### PR DESCRIPTION
required by https://github.com/src-d/applications-backlog/issues/4
depends on #319 #316

This PR adds support for GitHub OAuth log-in, as it was done by #308, which added support for Google OAuth log-in. Now, both login methods can coexist.

This PR does not handle the GitHub user, which should be done in another PR.
- The real work is done by d4493ace3def79bd792e95172fba7b1771275be8

See docs of usage on https://github.com/src-d/sourced-ce/pull/265

You can enable GitHub and Google OAuth providers running:

```shell
$ export OAUTH_ENABLED_PROVIDERS=github,google
$ export OAUTH_REGISTRATION_ROLE=Gamma
$ OAUTH_GOOGLE_CONSUMER_KEY=<google client_id> \
  OAUTH_GOOGLE_CONSUMER_SECRET=<google client_secret> \
  OAUTH_GITHUB_CONSUMER_KEY=<github client_id> \
  OAUTH_GITHUB_CONSUMER_SECRET=<github client_secret> \
  sourced init local .
```
which will enable this sign-in form:
<img src="https://user-images.githubusercontent.com/2437584/68427090-c5ed8580-01a9-11ea-9b0a-065ebd986bee.png" width="400" />


---

<!-- Please leave this template at the end of your description, checking the option that applies -->

* [x] I have updated the CHANGELOG file according to the conventions in [keepachangelog.com](https://keepachangelog.com)
* [ ] This PR contains changes that do not require a mention in the CHANGELOG file
